### PR TITLE
Add Docker image hash

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim@sha256:85ddc7b500c5e33a6eec44adbde8347a8a07714f03fc638f2cf4b13837bac601 
 
 RUN \
     adduser --system --disabled-password --shell /bin/bash vscode && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,28 @@
 # Changelog
 
-## [unreleased]
-### Needs
-+ Calcium Imaging .py files to mirror Electrophysiology
+## 0.1.1 - 2023-06-19
 
-## [0.0.0b2] - 2022-05-07
-### Added
-+ Folder structure to to imply NB order
-+ ERD->Diagram
-+ Change working directory to /home/notebooks
-+ Per above, move data to /home/notebooks, collapse modalities
++ Add - Docker image hash
 
-## [0.0.0b1] - 2021-06-11
-### Fixed 
-+ Notebook structure, polish
+## 0.1.0 - 2023-02-27
 
++ Update - Stable release before rework to incorporate Dev Container and GitHub Codespace
 
-## [0.0.0a] - 2020-04-13
-### Added 
-+ Major initial commits
+## 0.0.0b3
+
++ Update - Calcium Imaging .py files to mirror Electrophysiology
+
+## 0.0.0b2 - 2022-05-07
+
++ Add - Folder structure to to imply NB order
++ Update - ERD -> Diagram
++ Change - Working directory to /home/notebooks
++ Change - Per above, move data to /home/notebooks, collapse modalities
+
+## 0.0.0b1 - 2021-06-11
+
++ Fix - Notebook structure, polish
+
+## 0.0.0a - 2020-04-13
+
++ Add - Major initial commits

--- a/setup.py
+++ b/setup.py
@@ -7,19 +7,19 @@ long_description = """"
 DataJoint interactive tutorials with examples from electrophysiology and calcium-imaging
 """
 
-with open(path.join(here, 'requirements.txt')) as f:
+with open(path.join(here, "requirements.txt")) as f:
     requirements = f.read().splitlines()
 
 setup(
-    name='datajoint-tutorials',
-    version="0.1.0",
+    name="datajoint-tutorials",
+    version="0.1.1",
     description="DataJoint interactive tutorials",
     long_description=long_description,
-    author='DataJoint',
-    author_email='info@datajoint.com',
-    license='MIT',
-    url='https://github.com/datajoint/datajoint-tutorials',
-    keywords='neuroscience datajoint',
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    author="DataJoint",
+    author_email="support@datajoint.com",
+    license="MIT",
+    url="https://github.com/datajoint/datajoint-tutorials",
+    keywords="neuroscience datajoint",
+    packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     install_requires=requirements,
 )


### PR DESCRIPTION
## Description
- The base image recently changed and caused a build error in this Dev Container.

## Changes
- [x] Add Docker image hash to previous working version.
- [x] Test build of Dev Container environment locally and on Codespaces.
- [x] Declare tables in the database.
- [x] Update version and changelog.
- [ ] After merge, I will manually create a new GitHub tag and release.