### PR TITLE
Update base image and select local Python installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim@sha256:85ddc7b500c5e33a6eec44adbde8347a8a07714f03fc638f2cf4b13837bac601 
+FROM python:3.9-slim@sha256:5f0192a4f58a6ce99f732fe05e3b3d00f12ae62e183886bca3ebe3d202686c7f 
 
 RUN \
     adduser --system --disabled-password --shell /bin/bash vscode && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9-slim@sha256:5f0192a4f58a6ce99f732fe05e3b3d00f12ae62e183886bca3ebe3d202686c7f 
 
+ENV PATH /usr/local/bin:$PATH
+ENV PYTHON_VERSION 3.9.17
+
 RUN \
     adduser --system --disabled-password --shell /bin/bash vscode && \
     # install docker

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,7 +25,6 @@ RUN \
     pip install --no-cache-dir --upgrade black pip && \
     echo '. /etc/bash_completion' >> /home/vscode/.bashrc && \
     echo 'export PS1="\[\e[32;1m\]\u\[\e[m\]@\[\e[34;1m\]\H\[\e[m\]:\[\e[33;1m\]\w\[\e[m\]$ "' >> /home/vscode/.bashrc && \
-    # dircolors -b >> /home/vscode/.bashrc && \  # somehow fix colors
     apt-get clean
 COPY ./requirements.txt /tmp/
 RUN \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,9 @@
 		3306
 	],
 	"customizations": {
+		"settings": {
+			"python.pythonPath": "/usr/local/bin/python"
+		},
 		"vscode": {
 			"extensions": [
 				"ms-python.python@2023.8.0",

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ docker/standard_worker/.env
 
 # vscode
 .vscode/settings.json
+*.code-workspace
 
 # ssh
 *.ssh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## 0.1.2 - 2023-07-13
+
++ Update - Pin versions for VS Code extensions
++ Update - Dev Container base Docker image - python:3.7-slim -> python:3.9-slim
++ Add - Environment variables to select local Python install over Linux distribution of Python
+
 ## 0.1.1 - 2023-06-19
 
-+ Add - Docker image hash
++ Add - Docker image ID
 
 ## 0.1.0 - 2023-02-27
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, "requirements.txt")) as f:
 
 setup(
     name="datajoint-tutorials",
-    version="0.1.1",
+    version="0.1.2",
     description="DataJoint interactive tutorials",
     long_description=long_description,
     author="DataJoint",


### PR DESCRIPTION
## Description & Changes
- [x] The [EOL for Python 3.7](https://devguide.python.org/versions/) occurred on 2023-06-27.  Update the Dev Container base Docker image from Python 3.7 to Python 3.9.
- [x] The official Docker image for Python comes with [two python versions (local install and Linux distribution)](https://pythonspeed.com/articles/official-python-docker-image/).  Add environment variables to select the local Python install over the Linux distribution of Python.
- [x] Update gitignore
- [x] Update version and changelog
- [ ] After this pull request is merged, I will create a new tag and release.