### PR TITLE
Add GitHub Actions to pre-build Docker image for faster environment launch

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,12 +26,15 @@ RUN \
     echo '. /etc/bash_completion' >> /home/vscode/.bashrc && \
     echo 'export PS1="\[\e[32;1m\]\u\[\e[m\]@\[\e[34;1m\]\H\[\e[m\]:\[\e[33;1m\]\w\[\e[m\]$ "' >> /home/vscode/.bashrc && \
     apt-get clean
-COPY ./requirements.txt /tmp/
+
+COPY ./ /tmp/datajoint-tutorials
+
 RUN \
     # tutorial dependencies
     pip install --no-cache-dir black faker ipykernel && \
-    pip install --no-cache-dir -r /tmp/requirements.txt && \
-    rm /tmp/requirements.txt
+    pip install --no-cache-dir -e /tmp/datajoint-tutorials && \
+    # clean up
+    rm -rf /tmp/datajoint-tutorials
 
 ENV DJ_HOST fakeservices.datajoint.io
 ENV DJ_USER root

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,14 +27,13 @@ RUN \
     echo 'export PS1="\[\e[32;1m\]\u\[\e[m\]@\[\e[34;1m\]\H\[\e[m\]:\[\e[33;1m\]\w\[\e[m\]$ "' >> /home/vscode/.bashrc && \
     apt-get clean
 
-COPY ./ /tmp/datajoint-tutorials
+COPY ./requirements.txt /tmp/
 
 RUN \
     # tutorial dependencies
     pip install --no-cache-dir black faker ipykernel && \
-    pip install --no-cache-dir -e /tmp/datajoint-tutorials && \
-    # clean up
-    rm -rf /tmp/datajoint-tutorials
+    pip install --no-cache-dir -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
 
 ENV DJ_HOST fakeservices.datajoint.io
 ENV DJ_USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,11 @@
-// For format details, see https://aka.ms/devcontainer.json.
 {
 	"name": "DataJoint Tutorial",
 	"dockerComposeFile": "docker-compose.yaml",
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {
 		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}"
 	},
-	// https://containers.dev/features
 	"onCreateCommand": "pip install -e . && MYSQL_VER=8.0 docker compose down && MYSQL_VER=8.0 docker compose up --build --wait",
 	"postStartCommand": "docker volume prune -f",
 	"hostRequirements": {

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -3,13 +3,14 @@ services:
   app:
     cpus: 2
     mem_limit: 4g
-    build:
-      context: ..
-      dockerfile: ./.devcontainer/Dockerfile
+    # build:
+    #   context: ..
+    #   dockerfile: ./.devcontainer/Dockerfile
+    image: datajoint/datajoint_tutorials:latest
     extra_hosts:
       - fakeservices.datajoint.io:127.0.0.1
     volumes:
-      - ../..:/workspaces:cached
+      - ..:/workspaces/datajoint_tutorials:cached
       - docker_data:/var/lib/docker  # persist docker images
     privileged: true # only because of dind
 volumes:

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     extra_hosts:
       - fakeservices.datajoint.io:127.0.0.1
     volumes:
-      - ..:/workspaces/datajoint_tutorials:cached
+      - ..:/workspaces/datajoint-tutorials:cached
       - docker_data:/var/lib/docker  # persist docker images
     privileged: true # only because of dind
 volumes:

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   app:
     cpus: 2
     mem_limit: 4g
-    # build:
+    # build:  # build context is used when developing locally
     #   context: ..
     #   dockerfile: ./.devcontainer/Dockerfile
     image: datajoint/datajoint_tutorials:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,13 @@
+name: Release
+on:
+  workflow_dispatch:
+jobs:
+  devcontainer-build:
+    uses: datajoint/.github/.github/workflows/devcontainer-build.yaml@main
+  devcontainer-publish:
+    needs: 
+      - devcontainer-build
+    uses: datajoint/.github/.github/workflows/devcontainer-publish.yaml@main
+    secrets:
+      DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
+      DOCKERHUB_TOKEN: ${{secrets.DOCKERHUB_TOKEN}}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,10 @@
+name: Test
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1"
+jobs:
+  devcontainer-build:
+    uses: datajoint/.github/.github/workflows/devcontainer-build.yaml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 0.1.3 - 2023-09-14
 
 + Add - GitHub Actions to build Docker image and push to DockerHub
-+ Update - Dockerfile to install repository
 
 ## 0.1.2 - 2023-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.3 - 2023-09-14
 
-+ Add - GitHub Actions to build Dev Container
++ Add - GitHub Actions to build Docker image and push to DockerHub
 + Update - Dockerfile to install repository
 
 ## 0.1.2 - 2023-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.3 - 2023-09-14
+
++ Add - GitHub Actions to build Dev Container
++ Update - Dockerfile to install repository
+
 ## 0.1.2 - 2023-07-13
 
 + Update - Pin versions for VS Code extensions

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, "requirements.txt")) as f:
 
 setup(
     name="datajoint-tutorials",
-    version="0.1.2",
+    version="0.1.3",
     description="DataJoint interactive tutorials",
     long_description=long_description,
     author="DataJoint",


### PR DESCRIPTION
## Description

Currently each user of the Codespace must wait for the Docker image to build to be able to launch the environment.  The proposed changes pre-build the Docker image and host it on DockerHub.

## Changes
- [x] Add Docker image tag
- [x] Add `test.yaml` workflow to test the build of the Docker image on commit pushes, pull requests, manual triggers, and every Monday at 8am
- [x] Add `release.yaml` workflow to build and publish the Docker image on manual triggers
- [x] Update version and changelog
