### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
       args:
         - PY_VER=${PY_VER:-3.11}
-        - DISTRO=${DISTRO:-buster}
+        - DISTRO=${DISTRO:-bullseye}
     image: datajoint/datajoint_tutorials:latest
     volumes:
       - ..:/workspaces:cached


### PR DESCRIPTION
Docker hub updated the python 3.11 docker image for some reason... The old one doesn't exist anymore.   This one seemed equivalent.